### PR TITLE
Add total number of votes and vote difference as explicit shown values

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "start": "npm run develop",
+    "start": "yarn develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "deploy:pages": "yarn build && gh-pages -b prod -d public -m \"Deploy website\"",

--- a/src/components/GameGrid/PollGame/PollGameBar.tsx
+++ b/src/components/GameGrid/PollGame/PollGameBar.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
     },
   },
   gameText: {
-    fontSize: 14,
+    fontSize: 16,
     textAnchor: 'middle',
     dominantBaseline: 'middle',
     // shift down by 1px to make it look more centred
@@ -68,7 +68,12 @@ const PollGameBar: React.FC<Props> = ({ teamData, tweetId, hasStarted = true, vo
         className={clsx(classes.gameText, teamData.isMainColorLight ? classes.darkText : classes.lightText)}
       >
         <tspan className={classes.tocName}>{teamData.name}</tspan>
-        {hasStarted && <tspan> ({percentage}%)</tspan>}
+        {hasStarted && (
+          <tspan>
+            {' '}
+            ({percentage}%, {votes} votes)
+          </tspan>
+        )}
       </text>
     </a>
   )

--- a/src/components/GameGrid/Rounds/GameRound.tsx
+++ b/src/components/GameGrid/Rounds/GameRound.tsx
@@ -9,20 +9,6 @@ import clsx from 'clsx'
 import FormatDate from '../../../functions/formatDate'
 import SinglePoll from '../../../models/SinglePoll'
 
-interface Props {
-  data: SinglePoll
-  /**
-   * Removes the small date above the game.
-   * @default false
-   */
-  noDate?: boolean
-  /**
-   * Show a larger graph. Used for the active game box.
-   * @default false
-   */
-  large?: boolean
-}
-
 const useStyles = makeStyles({
   knockoutRoundsContainer: {
     display: 'flex',
@@ -43,6 +29,20 @@ const useStyles = makeStyles({
   },
 })
 
+interface Props {
+  data: SinglePoll
+  /**
+   * Removes the small date above the game.
+   * @default false
+   */
+  noDate?: boolean
+  /**
+   * Show a larger graph. Used for the active game box.
+   * @default false
+   */
+  large?: boolean
+}
+
 /**
  * Shows a `PollGame` and `Graph` for a specified game, provided as a `SinglePoll`.
  */
@@ -62,12 +62,14 @@ const GameRound: React.FC<Props> = ({ data, noDate, large }) => {
             Ending in {FormatDate.HoursMinsLong(new Date(data.twitterInfo.endTime).getTime() - new Date().getTime())}
           </Paragraph>
         )}
-        <Paragraph center>
-          Total Votes: {data.votesInfo[0].votes + data.votesInfo[1].votes}, Δ:&nbsp;
-          {data.votesInfo[0].votes > data.votesInfo[1].votes
-            ? data.votesInfo[0].votes - data.votesInfo[1].votes
-            : data.votesInfo[1].votes - data.votesInfo[0].votes}
-        </Paragraph>
+        {data.scheduledStartDay <= Date.now() && (
+          <Paragraph center>
+            Total Votes: {data.votesInfo[0].votes + data.votesInfo[1].votes}, <abbr title="Vote difference (delta)">Δ</abbr>:&nbsp;
+            {data.votesInfo[0].votes > data.votesInfo[1].votes
+              ? data.votesInfo[0].votes - data.votesInfo[1].votes
+              : data.votesInfo[1].votes - data.votesInfo[0].votes}
+          </Paragraph>
+        )}
         <PollGame
           teamData={data.getTeamData()}
           hasStarted={data.votingStatus !== 'UPCOMING'}

--- a/src/components/GameGrid/Rounds/GameRound.tsx
+++ b/src/components/GameGrid/Rounds/GameRound.tsx
@@ -62,6 +62,12 @@ const GameRound: React.FC<Props> = ({ data, noDate, large }) => {
             Ending in {FormatDate.HoursMinsLong(new Date(data.twitterInfo.endTime).getTime() - new Date().getTime())}
           </Paragraph>
         )}
+        <Paragraph center>
+          Total Votes: {data.votesInfo[0].votes + data.votesInfo[1].votes}, Δ:&nbsp;
+          {data.votesInfo[0].votes > data.votesInfo[1].votes
+            ? data.votesInfo[0].votes - data.votesInfo[1].votes
+            : data.votesInfo[1].votes - data.votesInfo[0].votes}
+        </Paragraph>
         <PollGame
           teamData={data.getTeamData()}
           hasStarted={data.votingStatus !== 'UPCOMING'}


### PR DESCRIPTION
This PR:

- Adds text below the date for each match to show total number of votes and the difference
- Adds text next to the percentage of game bars to explicitly show votes for each (so that it doesn't have to be read off the graph).
   - This has been validated to work on mobile and text still fits the bars for all TOCs 
- Minor change: Change the start script to `yarn develop`
