### PR TITLE
Make layout changes for the Round of 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-starter-default",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "David Wheatley",
     "email": "hi@davwheat.dev",

--- a/src/components/GameGrid/GameBoard.tsx
+++ b/src/components/GameGrid/GameBoard.tsx
@@ -8,6 +8,7 @@ import ActiveGame from './ActiveGame'
 
 import KnockoutRounds from './Rounds/KnockoutRounds'
 import GroupStages from './Rounds/GroupStages'
+import QuarterFinals from './Rounds/QuarterFinals'
 // import QuarterFinals from './Rounds/QuarterFinals'
 // import SemiFinals from './Rounds/SemiFinals'
 // import RunnerUp from './Rounds/RunnerUp'
@@ -28,13 +29,14 @@ interface Props {
 const GameBoard: React.FC<Props> = ({ gameData, gameNotes: propsGameNotes }: Props) => {
   const classes = useStyles()
 
-  const gameNotes = propsGameNotes || {
+  const gameNotes: IGameNotes = propsGameNotes || {
     knockout: {},
     groupStages: {},
     quarterFinal: {},
     semiFinal: {},
     runnerUp: {},
     final: {},
+    overall: null,
   }
 
   return (
@@ -47,44 +49,50 @@ const GameBoard: React.FC<Props> = ({ gameData, gameNotes: propsGameNotes }: Pro
       <TextContainer>
         <Shout>Other games</Shout>
 
-        <Loud>Round of 32</Loud>
-        <Paragraph>Knockout rounds began on Friday 15 January and will end on Saturday 30&nbsp;January.</Paragraph>
-      </TextContainer>
-
-      <KnockoutRounds gameNotes={gameNotes.knockout} knockoutRoundData={gameData.knockout} />
-
-      {/* NOTE: Move active rounds to the top when they start, but only once they start (so that the current round is always at the top). */}
-      <TextContainer>
         <Loud>Round of 16</Loud>
-        <Paragraph>The round of 16 will begin on Monday 1&nbsp;February.</Paragraph>
+        <Paragraph>The round of 16 will begin on Monday 1st&nbsp;February and end on Monday 8th&nbsp;February.</Paragraph>
       </TextContainer>
 
       <GroupStages gameNotes={gameNotes.groupStages} groupStageData={gameData.groupStages} />
 
-      {/**   <TextContainer>
+      <TextContainer>
         <Loud>Quarter Finals</Loud>
-        <Paragraph></Paragraph>
+        <Paragraph>Quarter Finals will begin on Wednesday 10th February and end on Saturday 13th&nbsp;February.</Paragraph>
       </TextContainer>
 
       <QuarterFinals gameNotes={gameNotes.quarterFinal} quarterFinalData={gameData.quarterFinal} />
 
       <TextContainer>
+        <Loud>Round of 32</Loud>
+        <Paragraph>Knockout rounds began on Friday 15th January and ended on Saturday 30th&nbsp;January.</Paragraph>
+      </TextContainer>
+
+      <KnockoutRounds gameNotes={gameNotes.knockout} knockoutRoundData={gameData.knockout} />
+
+      {/*
+        NOTE: Move active rounds to the top when they start, but only once they start (so that the current round is always at the top).
+        Also ensure the "Other Games" header is included in whatever is at the top.
+        The next round should also be below the current round.
+       */}
+
+      {/**
+      <TextContainer>
         <Loud>Semi Finals</Loud>
-        <Paragraph></Paragraph>
+        <Paragraph>Semi Finals will begin on Monday 15th February and end on Tuesday 16th&nbsp;February.</Paragraph>
       </TextContainer>
 
       <SemiFinals gameNotes={gameNotes.semiFinal} semiFinalData={gameData.semiFinal} />
 
       <TextContainer>
-        <Loud>3rd Place</Loud>
-        <Paragraph></Paragraph>
+        <Loud>3rd/4th Playoff</Loud>
+        <Paragraph>The 3rd/4th Play Playoff occurs on Thursday 18th&nbsp;February.</Paragraph>
       </TextContainer>
 
       <RunnerUp gameNotes={gameNotes.runnerUp[0]} runnerUpData={gameData.runnerUp} />
 
       <TextContainer>
         <Loud>Final</Loud>
-        <Paragraph></Paragraph>
+        <Paragraph>The Final occurs on Friday 19th&nbsp;February.</Paragraph>
       </TextContainer>
 
       <Finals gameNotes={gameNotes.final[0]} finalData={gameData.final} /> */}


### PR DESCRIPTION
Makes important layout changes for the Round of 16, namely:

- moves R16 to the top
- Place Quarter Finals below it (so users can more clearly see what the QFinal matches will be)
- Add `Paragraph` text for each round to say when the round begins and ends.